### PR TITLE
Support multi-valued CAS attributes

### DIFF
--- a/src/agent.js
+++ b/src/agent.js
@@ -120,7 +120,12 @@ class CasServerAgent extends EventEmitter {
 			
 			if (allAttributes) {
 				for (const key in allAttributes) {
-					parsedAttributes[key] = allAttributes[key][0];
+					if (allAttributes[key] && allAttributes[key].length > 1) {
+						parsedAttributes[key] = allAttributes[key];
+					}
+					else {
+						parsedAttributes[key] = allAttributes[key][0];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This allows access to all values in multi-valued CAS attributes while maintaining conversion behavior for single-valued attributes.  Single-valued CAS attributes, which are parsed from the ticket validation XML as arrays of length one, are still mapped to string-valued principal attributes.  Multi-valued CAS attributes are mapped directly rather than mapping only the first element as a string.  This is necessary to be able to apply AuthZ rules to multi-valued CAS attributes such as roles or group membership.

For this CAS service response, see the difference in the principal attributes below.
```xml
<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
  <cas:authenticationSuccess>
    <cas:user>jsmith@example.org</cas:user>
    <cas:attributes>
      ...
      <cas:mail>jsmith@example.org</cas:mail>
      <cas:displayName>Smith, Jane</cas:displayName>
      <cas:employeeNumber>123456</cas:employeeNumber>
      <cas:memberOf>CN=staff,OU=Employees,OU=Managed Groups,DC=example,DC=org</cas:memberOf>
      <cas:memberOf>CN=admins,OU=DevOps,OU=Managed Groups,DC=example,DC=org</cas:memberOf>
      <cas:memberOf>CN=support,OU=Facilities,OU=Managed Groups,DC=example,DC=org</cas:memberOf>
      <cas:userPrincipalName>jsmith@example.org</cas:userPrincipalName>
    </cas:attributes>
  </cas:authenticationSuccess>
</cas:serviceResponse>
```

Current principal:
```json
{
  "user": "jsmith@example.org",
  "attributes": {
      "mail": "jsmith@example.org",
      "displayName": "Smith, Jane",
      "employeeNumber": "123456",
      "memberOf": "CN=staff,OU=Employees,OU=Managed Groups,DC=example,DC=org",
      "userPrincipalName": "jsmith@example.org"
  }
}
```

Principal after this change:
```json
{
  "user": "jsmith@example.org",
  "attributes": {
      "mail": "jsmith@example.org",
      "displayName": "Smith, Jane",
      "employeeNumber": "123456",
      "memberOf": [
        "CN=staff,OU=Employees,OU=Managed Groups,DC=example,DC=org",
        "CN=admins,OU=DevOps,OU=Managed Groups,DC=example,DC=org",
        "CN=support,OU=Facilities,OU=Managed Groups,DC=example,DC=org"
        ],
      "userPrincipalName": "jsmith@example.org"
  }
}
```
